### PR TITLE
Update sensor.py for "friendly_name" attribute

### DIFF
--- a/custom_components/tautulli_active_streams/sensor.py
+++ b/custom_components/tautulli_active_streams/sensor.py
@@ -131,7 +131,7 @@ class TautulliStreamSensor(CoordinatorEntity, SensorEntity):
 
                 attributes.update({
                     # Additional keys fetched from the session
-                    "friendly_name": session.get("friendly_name"),
+                    "user_friendly_name": session.get("friendly_name"),
                     "username": session.get("username"),
                     "user_thumb": session.get("user_thumb"),
                     "container": session.get("container"),


### PR DESCRIPTION
The "friendly_name" conflicts with HA's built in use of friendly_name for additional attributes. Changed "friendly_name" to "user_friendly_name"